### PR TITLE
Docker build instructions to build the PJSIP lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ You can install everything on your local machine, or (the way I do) use an Ubunt
 1. Execute `./prepare-build-system`
 2. If everything goes well you should see all the compiled libraries (opus, openh264, openssl) in the <b>output</b> folder.
 
+## Build PJSIP using Docker
+1. Download JDK from the Oracle server and put it the the root directory (i.e. jdk-8u211-linux-x64.tar.gz)
+2. Change JDK_DIR and JDK_TAR args of the build.dockerfile file according to the downloaded JDK file
+3. Run ./build_with_docker.sh to build the lib
+
 ## Build PJSIP
 After you have successfully set up everything, to build PJSIP execute `./build`
 

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:latest as jdk_image
+
+ARG JDK_DIR=jdk1.8.0_211
+ARG JDK_TAR=jdk-8u211-linux-x64.tar.gz
+
+ENV JDK_DIR $JDK_DIR
+ENV JDK_TAR $JDK_TAR
+
+ENV PATH="/usr/lib/jvm/jdk1.8.0_211/bin:/usr/lib/jvm/jdk1.8.0_211/jre/bin:$PATH"
+ENV J2SDKDIR="/usr/lib/jvm/jdk1.8.0_211"
+ENV J2REDIR="/usr/lib/jvm/jdk1.8.0_211/jre"
+ENV JAVA_HOME="/usr/lib/jvm/jdk1.8.0_211"
+
+WORKDIR /home
+COPY $JDK_TAR /home
+
+RUN apt-get update && \
+	apt-get install -y sudo && \
+	apt-get install -y software-properties-common && \
+	mkdir -p /usr/lib/jvm && \
+	tar xzvf /home/jdk-8u211-linux-x64.tar.gz -C /usr/lib/jvm && \
+	update-alternatives --install "/usr/bin/java" "java" "/usr/lib/jvm/$JDK_DIR/bin/java" 0 && \
+	update-alternatives --install "/usr/bin/javac" "javac" "/usr/lib/jvm/$JDK_DIR/bin/javac" 0 && \
+	update-alternatives --set java /usr/lib/jvm/$JDK_DIR/bin/java && \
+	update-alternatives --set javac /usr/lib/jvm/$JDK_DIR/bin/javac
+
+FROM jdk_image
+
+WORKDIR /home
+COPY . /home/
+
+RUN ./prepare-build-system && \
+	./build

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker build --tag pjsip_android:latest --file ./build.dockerfile .
+CID=$(docker create pjsip_android:latest)
+docker cp ${CID}:/home/output/pjsip-build-output .
+docker rm ${CID}

--- a/config.conf
+++ b/config.conf
@@ -91,7 +91,7 @@ OPENSSL_TARGET_NDK_LEVEL=23
 ###############################################################################
 
 # OPENH264 Version to download
-OPENH264_VERSION=1.6.0
+OPENH264_VERSION=1.8.0
 
 # The URL from which to download OpenH264 sources tag
 OPENH264_DOWNLOAD_URL="https://github.com/cisco/openh264/archive/v$OPENH264_VERSION.tar.gz"
@@ -188,10 +188,10 @@ DOWNLOAD_LIBYUV=0
 DOWNLOAD_OPUS=1
 
 # Remove Tools directory after build
-REMOVE_TOOLS=1
+REMOVE_TOOLS=0
 
 # Set permission on output directory -- FOR DOCKER USE
-SET_PERMISSIONS=1
+SET_PERMISSIONS=0
 
 # Set the name of the user on the host machine
 OWNER="aenon"

--- a/openh264-build-target-archs
+++ b/openh264-build-target-archs
@@ -43,7 +43,7 @@ do
 
     elif [ "$arch" == "x86" ]
     then
-        ARGS="${ARGS}x86"
+        ARGS="${ARGS}x86 ENABLEPIC=Yes"
 
     elif [ "$arch" == "x86_64" ]
     then

--- a/prepare-build-system
+++ b/prepare-build-system
@@ -25,10 +25,10 @@ then
     # Setup Java 8
     sudo add-apt-repository -y ppa:webupd8team/java
     sudo apt-get update
-    sudo apt-get purge -y openjdk*
+    #sudo apt-get purge -y openjdk*
     echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
     echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-    sudo apt-get -y install oracle-java8-installer ant
+    sudo apt-get -y install ant
 
     sudo apt-get install -y unzip git
 


### PR DESCRIPTION
Added some instructions to build PJSIP using docker image including enabling fixes for relocation issues.