### PR TITLE
fix deps.

### DIFF
--- a/prepare-build-system
+++ b/prepare-build-system
@@ -30,7 +30,7 @@ then
     apt-get install -y openjdk-8-jdk
 
     DEPS="unzip git curl bzip2 binutils make autoconf openssl \
-          libssl-dev libopus0 libpcre3 libpcre3-dev build-essential nasm python" 
+          libssl-dev libopus0 libpcre3 libpcre3-dev build-essential nasm python2" 
     sh -c "dpkg --add-architecture i386; apt-get update && apt-get -y upgrade && apt-get install -y ${DEPS}"
 fi
 


### PR DESCRIPTION
prepare-build-system failure,


Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  2to3 python2-minimal:i386 python2:i386 python2-minimal python2 dh-python python-is-python3

E: Package 'python' has no installation candidate
