### PR TITLE
Conditional include opus definition in config site

### DIFF
--- a/build
+++ b/build
@@ -45,13 +45,20 @@ function setConfigSite {
     echo "#define PJMEDIA_AUDIO_DEV_HAS_ANDROID_JNI 0" >> "$CONFIG_SITE_PATH"
     echo "#define PJMEDIA_AUDIO_DEV_HAS_OPENSL 1" >> "$CONFIG_SITE_PATH"
     echo "#define PJSIP_AUTH_AUTO_SEND_NEXT 0" >> "$CONFIG_SITE_PATH"
-    echo "#define PJMEDIA_HAS_OPUS_CODEC 1" >> "$CONFIG_SITE_PATH"
-
+    
     # Check the README in patches README.md for more info
     if [ "${USE_FIXED_CALLID}" == "1" ]
     then
         echo "Changing PJSIP_MAX_URL_SIZE to 512"
         echo "#define PJSIP_MAX_URL_SIZE 512" >> "$CONFIG_SITE_PATH"
+    fi
+
+    if [ "${ENABLE_OPUS}" == "1" ]
+    then
+        echo "Enabling Opus codec"
+        echo "#define PJMEDIA_HAS_OPUS_CODEC 1" >> "$CONFIG_SITE_PATH"
+    else
+        echo "You have not enabled Opus in config_site"
     fi
 
     # If you are compiling pjsip with openssl you will likely use srtp


### PR DESCRIPTION
This PR fixes the issue #55.

This adds a check if Opus is enabled in config.conf in order to enable it in config_site.h on build script. 